### PR TITLE
Add JShell script building sense-nine on console

### DIFF
--- a/.bach/BuildSenseNine.java
+++ b/.bach/BuildSenseNine.java
@@ -1,0 +1,121 @@
+import static java.util.stream.Collectors.joining;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URI;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.StandardCopyOption;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+class BuildSenseNine {
+
+  public static void main(String... args) throws IOException {
+    Bach bach = new Bach();
+
+    // resolve dependencies (for "main" and "test")
+    resolve(bach, Paths.get(".idea", "libraries"));
+
+    // compile main
+    bach.javac(
+        javacOptions -> {
+          javacOptions.modulePaths = List.of(Paths.get(".bach", "resolved"));
+          javacOptions.moduleSourcePaths = List.of(Paths.get("src"));
+          javacOptions.destinationPath = Paths.get(".bach/out/javac/main");
+          return javacOptions;
+        });
+
+    // compile tests (error: not in a module on the module source path)
+    //    bach.javac(
+    //        javacOptions -> {
+    //          javacOptions.modulePaths = List.of(Paths.get(".bach", "resolved"));
+    //          javacOptions.moduleSourcePaths = List.of(Paths.get("test"));
+    //          javacOptions.destinationPath = Paths.get(".bach/out/javac/test");
+    //          return javacOptions;
+    //        });
+
+    // compile test (using legacy class-path)
+    List<Path> jars = Files.walk(Paths.get(".bach", "resolved")).collect(Collectors.toList());
+    List<Path> mods = Files.walk(Paths.get(".bach/out/javac/main"), 1).collect(Collectors.toList());
+    List<Path> classPath = new ArrayList<>();
+    classPath.addAll(mods);
+    classPath.addAll(jars);
+    bach.javac(
+        javacOptions -> {
+          javacOptions.classPaths = classPath;
+          javacOptions.classSourcePaths = List.of(Paths.get("test"));
+          javacOptions.destinationPath = Paths.get(".bach/out/javac/test");
+          return javacOptions;
+        });
+
+    // run tests (on the class-path...)
+    classPath.add(Paths.get(".bach/out/javac/test"));
+    test(bach, classPath.stream().map(Object::toString).collect(joining(File.pathSeparator)));
+  }
+
+  private static void resolve(Bach bach, Path ideaLibraryDirectory) throws IOException {
+    Path mavenRepository = Paths.get(System.getProperty("user.home"), ".m2", "repository");
+    System.out.println("using local maven repository: " + mavenRepository);
+    Files.walk(ideaLibraryDirectory)
+        .filter(path -> path.getFileName().toString().endsWith(".xml"))
+        .forEach(xml -> resolve(bach, mavenRepository, xml));
+  }
+
+  private static void resolve(Bach bach, Path mavenRepository, Path ideaLibraryFile) {
+    System.out.println("resolving " + ideaLibraryFile);
+    Path resolved = Paths.get(".bach", "resolved");
+    try {
+      Files.createDirectories(resolved);
+      List<String> lines = Files.readAllLines(ideaLibraryFile);
+      boolean parse = false;
+      for (String line : lines) {
+        line = line.trim();
+        if (!parse) {
+          if (line.equals("<CLASSES>")) {
+            parse = true;
+          }
+          continue;
+        }
+        if (line.equals("</CLASSES>")) {
+          return;
+        }
+        line = line.substring("<root url=\"jar://$MAVEN_REPOSITORY$/".length());
+        line = line.substring(0, line.indexOf("!/\" />"));
+        Path source = mavenRepository.resolve(line);
+        Path target = resolved.resolve(source.getFileName());
+        if (Files.exists(source)) {
+          Files.copy(source, target, StandardCopyOption.REPLACE_EXISTING);
+          continue;
+        }
+        // extract maven artifact coordinates
+        String base = line.substring(0, line.lastIndexOf('/'));
+        System.out.println(base);
+        String version = base.substring(base.lastIndexOf('/') + 1, base.length());
+        System.out.println(version);
+        String artifact =
+            line.substring(line.lastIndexOf('/') + 1, line.lastIndexOf("-" + version));
+        System.out.println(artifact);
+        String group = line.substring(0, line.lastIndexOf("/" + artifact + "/"));
+        System.out.println(group);
+        bach.resolve(group, artifact, version);
+      }
+    } catch (IOException e) {
+      throw new Error("resolving " + ideaLibraryFile + " failed", e);
+    }
+  }
+
+  private static void test(Bach bach, String classPath) throws IOException {
+    String repo = "http://repo1.maven.org/maven2";
+    String user = "org/junit/platform";
+    String name = "junit-platform-console-standalone";
+    String version = "1.0.0-M5";
+    String file = name + "-" + version + ".jar";
+    URI uri = URI.create(String.join("/", repo, user, name, version, file));
+    Path path = Paths.get(".bach/tools").resolve(name);
+    Path jar = bach.download(uri, path, file, p -> true);
+    bach.call("java", "-ea", "-jar", jar, "--class-path", classPath, "--scan-classpath");
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 out
 .idea/workspace.xml
 tweetdata60-mins.txt
+.bach/Bach.java
+.bach/resolved
+.bach/tools

--- a/.idea/libraries/org_eclipse_jetty_websocket_javax_websocket_server_impl_9_4_1_v20170120.xml
+++ b/.idea/libraries/org_eclipse_jetty_websocket_javax_websocket_server_impl_9_4_1_v20170120.xml
@@ -24,9 +24,9 @@
       <root url="jar://$MAVEN_REPOSITORY$/org/eclipse/jetty/jetty-client/9.4.1.v20170120/jetty-client-9.4.1.v20170120.jar!/" />
       <root url="jar://$MAVEN_REPOSITORY$/org/eclipse/jetty/websocket/websocket-common/9.4.1.v20170120/websocket-common-9.4.1.v20170120.jar!/" />
       <root url="jar://$MAVEN_REPOSITORY$/org/eclipse/jetty/websocket/websocket-api/9.4.1.v20170120/websocket-api-9.4.1.v20170120.jar!/" />
-      <root url="jar://$MAVEN_REPOSITORY$/javax/websocket/javax.websocket-api/1.0/javax.websocket-api-1.0.jar!/" />
       <root url="jar://$MAVEN_REPOSITORY$/org/eclipse/jetty/websocket/websocket-server/9.4.1.v20170120/websocket-server-9.4.1.v20170120.jar!/" />
       <root url="jar://$MAVEN_REPOSITORY$/org/eclipse/jetty/websocket/websocket-servlet/9.4.1.v20170120/websocket-servlet-9.4.1.v20170120.jar!/" />
+      <root url="jar://$MAVEN_REPOSITORY$/javax/websocket/javax.websocket-api/1.1/javax.websocket-api-1.1.jar!/" />
     </CLASSES>
     <JAVADOC />
     <SOURCES />

--- a/build.jsh
+++ b/build.jsh
@@ -1,0 +1,16 @@
+//$JAVA_HOME/bin/jshell --show-version $0 $@; exit $?
+
+URL url = new URL("https://raw.githubusercontent.com/sormuras/bach/master/src/main/java/Bach.java");
+Path target = Paths.get(".bach")
+Path script = target.resolve("Bach.java")
+if (Files.notExists(script)) {
+  Files.createDirectories(target);
+  try (InputStream stream = url.openStream()) { Files.copy(stream, script); }
+}
+
+/open .bach/Bach.java
+/open .bach/BuildSenseNine.java
+
+BuildSenseNine.main()
+
+/exit

--- a/empathy.iml
+++ b/empathy.iml
@@ -2,7 +2,9 @@
 <module type="JAVA_MODULE" version="4">
   <component name="NewModuleRootManager" inherit-compiler-output="true">
     <exclude-output />
-    <content url="file://$MODULE_DIR$" />
+    <content url="file://$MODULE_DIR$">
+      <sourceFolder url="file://$MODULE_DIR$/.bach" isTestSource="false" />
+    </content>
     <orderEntry type="inheritedJdk" />
     <orderEntry type="sourceFolder" forTests="false" />
   </component>


### PR DESCRIPTION
## Overview

This PR adds "headless" compilation and testing support to **sense-nine**.

It utilizes the Java 9 JShell with the JShell Builder called [bach](https://github.com/sormuras/bach). Launch the script via `jshell build.jsh` from the root directory to build the project it on the console. CI environments like Travis CI are supported. I could add a `.travis.yml` if you want.

Cheers!

## `.bach/BuildSenseNine.java`

- You may run (and debug) **BuildSenseNine** directly from within IDEA.
- It resolves the project's dependencies by scanning `.idea/libraries` files. That's convenient but not very stable.
- Tests are compiled and launched on the class-path.

## Test run

```
.
+-- JUnit Jupiter [OK]
| +-- HappinessChartDataTest [OK]
| | +-- should have ten bars with value zero before data received [OK]
| | +-- should increment the bar that matches the current minute if the message is happy [OK]
| | '-- should not increment the bar that matches the current minute if the message is not happy [OK]
| +-- MoodChartDataTest [OK]
| | +-- should increment happy slice [OK]
| | '-- should increment sad slice [OK]
| +-- LeaderboardDataTest [OK]
| | +-- should count number of tweets by the same person [OK]
| | +-- should add a user to the correct position when they have enough tweets and shuffle others downwards [OK]
| | '-- should resort the leaderboard if a user rises up [OK]
| +-- MoodServiceTest [OK]
| | +-- should correctly identify happy messages [OK]
| | +-- should correctly identify mixed messages [OK]
| | +-- should correctly identify sad messages [OK]
| | +-- should correctly identify mixed messages with multiple moods [OK]
| | +-- should not have any mood for messages that are neither happy or sad [OK]
| | '-- should correctly identify happy messages that are not lower case [OK]
| +-- BroadcastingServerEndpointTest [OK]
| | +-- should not try to forward messages to closed sessions [OK]
| | +-- should forward messages to all open sessions [OK]
| | '-- should accept messages and publish the toString() representation [OK]
| +-- CannedTweetsServiceTest [OK]
| | +-- shouldStop() [OK]
| | '-- shouldMessageClientsWithTweetsReceived() [OK]
| +-- TweetParserTest [OK]
| | +-- should return the user's twitter handle [OK]
| | '-- should return the tweet itself from the full Twitter JSON [OK]
| '-- UserServiceTest [OK]
|   '-- shouldTurnTweetsIntoTwitterHandles() [OK]
'-- JUnit Vintage [OK]

Test run finished after 2406 ms
[        10 containers found      ]
[         0 containers skipped    ]
[        10 containers started    ]
[         0 containers aborted    ]
[        10 containers successful ]
[         0 containers failed     ]
[        22 tests found           ]
[         0 tests skipped         ]
[        22 tests started         ]
[         0 tests aborted         ]
[        22 tests successful      ]
[         0 tests failed          ]
```